### PR TITLE
Enforce Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,27 @@
+AllCops:
+  TargetRubyVersion: 2.4
+
+Metrics/LineLength:
+  Max: 200
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,9 +11,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.disable_monkey_patching!
   config.warnings = true
-  if config.files_to_run.one?
-    config.default_formatter = "doc"
-  end
+  config.default_formatter = "doc" if config.files_to_run.one?
   config.profile_examples = 10
   config.order = :random
   Kernel.srand config.seed

--- a/spec/splunk/logger/logfmt_formatter_spec.rb
+++ b/spec/splunk/logger/logfmt_formatter_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe Splunk::Logger::LogfmtFormatter do
 
     context 'when passed a hash' do
       it 'logs keys and values in logfmt to the logger via info' do
-        expect(formatter.call(severity, time, progname, { foo: 'bar' })).to match(/\A#{PREFIX} foo=bar\n\z/)
+        expect(formatter.call(severity, time, progname, foo: 'bar')).to match(/\A#{PREFIX} foo=bar\n\z/)
       end
     end
 
     context 'when passed a nested hash' do
       it 'raises an exception' do
-        expect { formatter.call(severity, time, progname, { foo: { bar: 'baz' } }) }.to raise_error(ArgumentError)
+        expect { formatter.call(severity, time, progname, foo: { bar: 'baz' }) }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/splunk/logger_spec.rb
+++ b/spec/splunk/logger_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Splunk::Logger do
     it 'logs to the logger with the info severity' do
       logger = Logger.new(STDOUT)
       splunk_logger = Splunk::Logger.new(logger)
-      expect(logger).to receive(:info).with({ foo: 'bar' })
-      splunk_logger.log({ foo: 'bar' })
+      expect(logger).to receive(:info).with(foo: 'bar')
+      splunk_logger.log(foo: 'bar')
     end
   end
 end

--- a/splunk-logger.gemspec
+++ b/splunk-logger.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/cultureamp/splunk-ruby'
 
   s.add_development_dependency "rspec", "~> 3.7"
+  s.add_development_dependency "rubocop", "~> 0.55.0"
 end


### PR DESCRIPTION
When vendoring this in Murmur, I saw that some Rubocop rules weren't enforced. I've added `.rubocop.yml` here, enforcing many of the same rules from Murmur.